### PR TITLE
Add basic Makefile and platform-specific checks to achieve Linux support

### DIFF
--- a/porosity/porosity/Contract.cpp
+++ b/porosity/porosity/Contract.cpp
@@ -907,7 +907,11 @@ Contract::StructureIfs(
 
     if (trueBlock && ((getBlockSuccessorsCount(trueBlock) == 1)) /*&&
         (trueBlock->dstDefault == falseLocation)*/) {
-        for each(auto instrState in _block->instructions) {
+#ifdef __WIN32
+        for each (auto instrState in _block->instructions) {
+#else
+        for (auto instrState : _block->instructions) {
+#endif
             ifStmt.setCondition(instrState);
         }
         // ifStmt.NegateCondition();

--- a/porosity/porosity/Makefile
+++ b/porosity/porosity/Makefile
@@ -1,0 +1,11 @@
+SOURCES=$(shell find . -name "*.cpp")
+OBJECTS=$(SOURCES:%.cpp=%.o)
+TARGET=porosity
+
+all: $(TARGET)
+
+$(TARGET): $(OBJECTS)
+	$(LINK.cpp) $^ $(LOADLIBES) $(LDLIBS) -o $@
+
+clean:
+	rm -f $(TARGET) $(OBJECTS)

--- a/porosity/porosity/Output.cpp
+++ b/porosity/porosity/Output.cpp
@@ -1,5 +1,6 @@
 #include "Porosity.h"
 
+#ifdef _WIN32
 #include <windows.h>
 
 uint16_t
@@ -32,3 +33,20 @@ Red(char *Format, ...)
 
     SetConsoleTextAttribute(Handle, Color);
 }
+
+#else
+#include <stdarg.h>
+
+void
+Red(char *Format, ...)
+{
+    va_list va;
+
+    va_start(va, Format);
+    vprintf(C_RED, va);
+    vprintf(Format, va);
+    vprintf(C_RESET, va);
+    va_end(va);
+}
+
+#endif

--- a/porosity/porosity/Output.h
+++ b/porosity/porosity/Output.h
@@ -1,3 +1,8 @@
+#ifdef __WIN32
 uint16_t GetConsoleTextAttribute(uint32_t hConsole);
+#else
+#define C_RED   "[0;31m"
+#define C_RESET "[0m"
+#endif
 
 void Red(char *Format, ...);


### PR DESCRIPTION
With these changes, porosity compiles on Linux/g++ and retains the ANSI coloring.

Caveats:
  - Using `autoconf`/`automake` might be better
  - I haven't tested Windows/VS compilation
  - Needing the platform check around the `for each` isn't great