### PR TITLE
Fix a couple of segfaults

### DIFF
--- a/porosity/porosity/Contract.cpp
+++ b/porosity/porosity/Contract.cpp
@@ -992,28 +992,40 @@ Contract::decompileBlock(
             break;
         case Instruction::SSTORE:
         {
+            
+            if (i->stack.size()) {
 
-            string valueName = "";
-            switch (i->stack[1].type) {
-                case ConstantComputed:
-                case Constant:
-                {
-                    stringstream mod;
-                    mod << "0x" << std::hex << i->stack[1].value;
-                    valueName = mod.str();
-                    // mod << "0x" << std::hex << second->value;
-                    break;
+                string valueName = "";
+                switch (i->stack[1].type) {
+                    case ConstantComputed:
+                    case Constant:
+                    {
+                        stringstream mod;
+                        mod << "0x" << std::hex << i->stack[1].value;
+                        valueName = mod.str();
+                        // mod << "0x" << std::hex << second->value;
+                        break;
+                    }
+                    default:
+                        valueName = (i->stack[1].exp.size()) ? i->stack[1].exp : i->stack[1].name;
+                        break;
                 }
-                default:
-                    valueName = (i->stack[1].exp.size()) ? i->stack[1].exp : i->stack[1].name;
-                    break;
+                exp = "store[" + i->stack[0].name + "] = " + valueName + ";";
+            } else {
+                exp = "store[?];";
             }
-            exp = "store[" + i->stack[0].name + "] = " + valueName + ";";
+            
             if (_block->Flags & BlockFlags::NoMoreSSTORE) errCode |= DCode_Err_ReentrantVulnerablity;
             break;
+
         }
         case Instruction::RETURN:
-            exp = "return " + i->stack[0].name + ";";
+            if (i->stack.size()) {
+                exp = "return " + i->stack[0].name + ";";
+            } else {
+                exp = "return;";
+            }
+                
             result = false;
             break;
         case Instruction::STOP:


### PR DESCRIPTION
Porosity segfaulted on the following input:

$ Porosity --code "0x606060405236156100305763ffffffff60e060020a600035041663c4d66de881146101d4578063e06174e4146101f2575b6101d25b60008080803615156100885760408051600160a060020a033316815234602082015281517fe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c929181900390910190a16101cc565b6000805460408051602090810184905281517f206bd36200000000000000000000000000000000000000000000000000000000815284357fffffffff00000000000000000000000000000000000000000000000000000000811660048301529251929850600160a060020a039093169363206bd3629360248082019492918390030190829087803b151561011857fe5b60325a03f1151561012557fe5b505060408051805160008054602093840182905284517fd4b839920000000000000000000000000000000000000000000000000000000081529451929850600160a060020a0316945063d4b83992936004808201949392918390030190829087803b151561018f57fe5b60325a03f1151561019c57fe5b505060405151925036905060008037826000366000856127105a03f490508015156101c75760006000fd5b826000f35b50505050565b005b34156101dc57fe5b6101d2600160a060020a036004351661021e565b005b34156101fa57fe5b610202610222565b60408051600160a060020a039092168252519081900360200190f35b5b50565b600054600160a060020a0316815600a165627a7a723058205557ac428f3c022b91b24735f7b95dc5f615e8af50417aded8b433c9b59447a50029" --decompile

I added some additional stack.size() checks in Contract.cpp which fixes the crashes. There seems to be a more fundamental problem though as the contract isn't decompiled correctly:

function func_c4d66de8 {
      if (!msg.value) {
      }
      return;
}


LOC: 5
Hash: 0xE06174E4
function func_e06174e4 {
      if (!msg.value) {
      }
      return;
      store[?];
      return;
}


LOC: 7

 