### PR TITLE
update readme: add info about boost dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,4 +476,10 @@ LOC: 3
 
 `make`
 
+*Note*: you may need to install [boost c++](http://www.boost.org/) dependency.
 
+Using HomeBrew:
+`brew install boost`
+
+Using MacPorts:
+`sudo port install boost`


### PR DESCRIPTION
resolves the problems I've faced with during installation:
c++ -std=c++14   -c -o Utils.o Utils.cpp
In file included from Utils.cpp:17:
./Porosity.h:22:10: fatal error: 'boost/dynamic_bitset.hpp' file not found
#include <boost/dynamic_bitset.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make: *** [Utils.o] Error 1