### PR TITLE
Allow code strings to have embedded whitespace ...

### DIFF
--- a/porosity/porosity/CommonData.cpp
+++ b/porosity/porosity/CommonData.cpp
@@ -93,13 +93,28 @@ std::string dev::randomWord()
 	return ret;
 }
 
+// Converts  string _s to bytes. _s can optionally have a leading
+// "0x". Interior "\n" and " " in the string are ignored.
 bytes dev::fromHex(std::string const& _s, WhenError _throw)
 {
+	// Copy s and strip optional leading "0x"
 	unsigned s = (_s.size() >= 2 && _s[0] == '0' && _s[1] == 'x') ? 2 : 0;
-	std::vector<uint8_t> ret;
-	ret.reserve((_s.size() - s + 1) / 2);
+	std::string s2 = _s;
 
-	if (_s.size() % 2)
+	std::vector<uint8_t> ret;
+
+	// Strip whitespace
+	int j = -1;
+	for (int i = s; i < _s.size(); i++) {
+		if (_s[i] == '\n' || _s[i] == ' ') continue;
+		j++;
+		if (i != j) s2[j] = _s[i];
+	}
+
+	s2.resize(j+1);
+	ret.reserve((s2.size() + 1) / 2);
+
+	if (s2.size() % 2)
 	{
 		int h = _fromHex(_s[s++]);
 		if (h != -1)
@@ -109,10 +124,10 @@ bytes dev::fromHex(std::string const& _s, WhenError _throw)
 		else
 			return bytes();
 	}
-	for (unsigned i = s; i < _s.size(); i += 2)
+	for (unsigned i = s; i < s2.size(); i += 2)
 	{
-		int h = _fromHex(_s[i]);
-		int l = _fromHex(_s[i + 1]);
+		int h = _fromHex(s2[i]);
+		int l = _fromHex(s2[i + 1]);
 		if (h != -1 && l != -1)
 			ret.push_back((byte)(h * 16 + l));
 		else if (_throw == WhenError::Throw)

--- a/porosity/porosity/Porosity.cpp
+++ b/porosity/porosity/Porosity.cpp
@@ -142,6 +142,11 @@ parse(
 
                 out->codeByte = fromHex(str);
                 out->codeByteRuntime = fromHex(str);
+		if (out->codeByteRuntime.empty())
+		{
+		    printf("%s: conversion to hex in --code-file option failed.\n", __FUNCTION__);
+		    return false;
+		}
             }
         }
         else if ((kw == "--disassm") || (kw == "--disasm")) {
@@ -175,7 +180,8 @@ parse(
     //
     if (!out->debugMode) {
         if (out->codeByteRuntime.empty()) {
-            printf("%s: Please at least provide some byte code (--code) or run it in debug mode (--debug) with pre-configured inputs.\n", __FUNCTION__);
+            printf("%s: Please at least provide some byte code (--code or --code-file) or run it in debug mode (--debug) to use the pre-configured inputs.\n",
+		   __FUNCTION__);
             return false;
         }
 
@@ -192,13 +198,13 @@ help() {
     printf("\n");
     printf("Usage: porosity [options]\n");
     printf("Debug:\n");
-    printf("    --debug                             - Enable debug mode. (testing only - no input parameter needed.)\n\n");
+    printf("    --debug                             - Enable debug mode. (testing using predefined inputs; other parameters are ignored.)\n\n");
     printf("Input parameters:\n");
-    printf("    --code <bytecode>                   - Ethereum bytecode. (mandatory)\n");
+    printf("    --code <bytecode>                   - Ethereum bytecode. (mandatory unless --code-file or --debug is given)\n");
     printf("    --code-file <filename>              - Read ethereum bytecode from file\n");
     printf("    --arguments <arguments>             - Ethereum arguments to pass to the function. (optional, default data set provided if not provided.)\n");
     printf("    --abi <arguments>                   - Ethereum Application Binary Interface (ABI) in JSON format. (optional but recommended)\n");
-    printf("    --hash <hashmethod>                 - Work on a specific function, can be retrieved wit --list. (optional)\n");
+    printf("    --hash <hashmethod>                 - Work on a specific function, can be retrieved with --list. (optional)\n");
     printf("\n");
     printf("Features:\n");
     printf("    --list                              - List identified methods/functions.\n");


### PR DESCRIPTION
* better error message when giving an invalid code-file
* fix a small typos and add doc tweaks

Note all hex strings now allow spaces and newlines, and this
includes both the --code and --code-file options